### PR TITLE
removed duplicate produce with multiple produce tags

### DIFF
--- a/src/Marketplace/MarketplaceScreen.js
+++ b/src/Marketplace/MarketplaceScreen.js
@@ -405,6 +405,9 @@ export default function MarketplaceScreen({ navigation }) {
       if (favorites) {
         filteredList = filteredList.filter((item) => item.Favorited);
       }
+      filteredList = filteredList.filter(
+        (v, i, a) => a.findIndex((v2) => v.Name === v2.Name) === i,
+      );
       return filteredList;
     }
     if (filteredList.length === 0 && favorites) {


### PR DESCRIPTION
because an item can have multiple tags, they accidentally get added multiple times if more than 1 filter is chosen